### PR TITLE
Remove excon

### DIFF
--- a/lib/rspec/webservice_matchers/have_a_valid_cert.rb
+++ b/lib/rspec/webservice_matchers/have_a_valid_cert.rb
@@ -25,12 +25,12 @@ module RSpec
         # 200. HTTPie and Curl are able to.
         # See https://github.com/excon/excon/issues/546
         def fix_for_excon_bug(error_message)
-          return error_message unless buggy_excon_message?(error_message)
+          return error_message unless buggy_message?(error_message)
           'Unable to verify the certificate because a redirect was detected'
         end
 
-        def buggy_excon_message?(text)
-          text =~ /Unable to verify certificate, please/
+        def buggy_message?(text)
+          text =~ /Unable to verify|verify failed/
         end
       end
     end

--- a/lib/rspec/webservice_matchers/util.rb
+++ b/lib/rspec/webservice_matchers/util.rb
@@ -67,7 +67,7 @@ module RSpec
           c.options[:timeout] = TIMEOUT_IN_SECONDS
           c.options[:open_timeout] = OPEN_TIMEOUT_IN_SECONDS
           c.use(FaradayMiddleware::FollowRedirects, limit: 4) if follow
-          c.adapter :excon
+          c.adapter :net_http
         end
       end
 

--- a/lib/rspec/webservice_matchers/version.rb
+++ b/lib/rspec/webservice_matchers/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module WebserviceMatchers
-    VERSION = '4.4.1'
+    VERSION = '4.4.2'
   end
 end

--- a/spec/rspec/webservice_matchers/protcol_spec.rb
+++ b/spec/rspec/webservice_matchers/protcol_spec.rb
@@ -49,7 +49,8 @@ describe 'be_up' do
   end
 
   it 'is available via a public API' do
-    expect(RSpec::WebserviceMatchers::Util.up?('http://www.website.com/')).to be true
+    status = RSpec::WebserviceMatchers::Util.up?('http://www.website.com/')
+    expect(status).to be true
   end
 
   it 'gives relevant error output' do
@@ -60,5 +61,9 @@ describe 'be_up' do
 
   it 'succeeds even if the site times out on the first try' do
     expect('http://www.timeout-once.com').to be_up
+  end
+
+  it 'works on cars.com' do
+    expect('http://cars.com').to be_up
   end
 end


### PR DESCRIPTION
E.g., the site cars.com when queried with excon would return a redirect
to “https://cars.com:80”.